### PR TITLE
port the two pending README contributions to the 2026 table format

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Living projects with real 2024-2026 releases, typically focused on one or a few 
 | **KInit** | :slovakia: Slovakia | Slovak NLP | open (research) | Active on GitHub | [github.com/kinit-sk](https://github.com/kinit-sk) |
 | **LAION** | :de: Germany / International | Open datasets and multimodal | open | Continuously active | [laion.ai](https://laion.ai/) |
 | **Le Bon LLM** | :fr: France | French community | open | Community initiative | [lebonllm.fr](https://www.lebonllm.fr/) |
+| **Llama-Krikri** (ILSP, Athena Research Center) | :greece: Greece | Greek LLMs and Greek evaluation suite | Llama 3.1 | Krikri 8B Instruct updated 12/2025, Greek evaluation datasets updated 2026 | [Krikri collection](https://huggingface.co/collections/ilsp/krikri-8b-68273283651ba864d44fc33a), [Greek evaluation suite](https://huggingface.co/collections/ilsp/ilsp-greek-evaluation-suite-6827304d5bf8b70d0346b02c), [ILSP on HF](https://huggingface.co/ilsp) |
 | **LLM for Romanian (ILDS)** | :ro: Romania | Romanian | open (research) | Active 2024-2025 | [ilds.ro](https://ilds.ro/llm-for-romanian/) |
 | **NLP Odyssey** | :it: Italy | NLP libs and models | open | Active OpenCollective | [OpenCollective](https://opencollective.com/nlpodyssey) |
 | **NOUS Research** | :gb: United Kingdom | Instruction & alignment | mixed open | Regular releases in 2025-2026 | [HF](https://huggingface.co/NousResearch) |
@@ -99,6 +100,7 @@ First-generation BERT-family models and early monolingual encoders. Based on pub
 | **Insait, original BgGPT** (pre-Gemma 2) | bg | :bulgaria: Bulgaria | [Launch post](https://bggpt.ai/blog/2024-02-18-launching-the-first-free-and-open-bulgarian-llm/) |
 | **Lucie-7B / Lucie-7B-Instruct** (OpenLLM France) | multilingual, fr-first | :fr: France | [Paper](https://arxiv.org/abs/2503.12294), succeeded by Luciole in 2026 |
 | **LVBERT** | lv | :latvia: Latvia | [GitHub](https://github.com/LUMII-AILab/LVBERT) |
+| **Meltemi-7B** (ILSP, Athena Research Center) | el | :greece: Greece | [Meltemi collection](https://huggingface.co/collections/ilsp/meltemi-7b-682731cced6c20f2dc1b725c), [Paper](https://arxiv.org/abs/2407.20743) - first open LLM for Greek (Mistral-based, 2024), succeeded by Llama-Krikri |
 | **Polbert** | pl | :poland: Poland | [HF](https://huggingface.co/dkleczek) |
 | **Sabia** | pt-br | :portugal: Portugal | [Paper](https://arxiv.org/abs/2304.07880) |
 | **Serbian LLM eval** | sr | :serbia: Serbia | [GitHub](https://github.com/gordicaleksa/serbian-llm-eval) |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Openly licensed foundation LLMs trained from scratch in Europe (or by European t
 | **Pleias 1.0** (Pleias) | 350M, 1.2B, 3B | multilingual, trained on Common Corpus only | Apache 2.0 | 12/2024 | France | [pleias.ai](https://pleias.ai/research), [HF](https://huggingface.co/PleIAs), [Overview](https://simonwillison.net/2024/Dec/5/pleias-llms/) |
 | **Salamandra / ALIA** (BSC, Projecte Aina) | 2B, 7B, 40B | ca, es, gl, eu + EU | Apache 2.0 | 2024-2025 | Spain | [Salamandra family](https://projecteaina.cat/tech/en/introducing-the-salamandra-family-of-models/), [HF](https://huggingface.co/projecte-aina) |
 | **Teuken-7B** (OpenGPT-X / Fraunhofer IAIS / Jülich) | 7B | 24 EU official languages | Apache 2.0 | v0.6, late 2025 | Germany / EU | [Press release](https://www.iais.fraunhofer.de/en/press-events/press-releases/press-release-241126.html), [HF](https://huggingface.co/openGPT-X) |
+| **TildeOpen LLM** (Tilde) | 30B, plus a 64k-context variant | 34 European languages, Baltic and Eastern European focus | CC-BY-4.0 | 30B: 09/2025, integrated into Tilde MT 02/2026 | Latvia | [tilde.ai](https://tilde.ai/tildeopen-llm/), [HF](https://huggingface.co/TildeAI/TildeOpen-30b) |
 
 ### Speech, multimodal and agent foundation models
 
@@ -83,7 +84,7 @@ Living projects with real 2024-2026 releases, typically focused on one or a few 
 | **PORO / Viking / Europa** (ex-Silo AI, now AMD) | :fi: Finland / International | Nordic + multilingual | Apache 2.0 | Models still openly available, roadmap now under AMD | [Announcement](https://www.silo.ai/blog/poro-a-family-of-open-models-that-bring-european-languages-to-the-frontier) |
 | **SiloGen platform** (AMD, ex-Silo AI) | :fi: Finland (AMD) | Enterprise LLM ops | mixed | Post-acquisition 2024+ | See section 4 |
 | **TartuNLP** | :estonia: Estonia | Estonian NLP, translation | open | Continuously maintained | [tartunlp.ai](https://tartunlp.ai/) |
-| **Tilde AI** | :latvia: Latvia / :lithuania: Lithuania | Baltic MT, LLM services | mixed | Active commercial + research | [tilde.com](https://www.tilde.com/) |
+| **Tilde AI** | :latvia: Latvia | Baltic MT and LLM services, publisher of TildeOpen LLM (see section 1) | mixed | Active commercial + research | [tilde.com](https://www.tilde.com/) |
 
 ---
 


### PR DESCRIPTION
Both open PRs (#6 and #7) were opened on 10 October 2025 against the pre-refactor README and target per-country bullet sections (`### Greek initiatives`, `### Lithuanian initiatives`) that no longer exist since `3415858 refactor and update (August 2026)`. GitHub reports both as conflicting and a rebase would amount to a full rewrite, so their content is ported here instead, with `Co-authored-by` trailers preserving credit.

## From #6, ILSP / Athena Research Center

Greece was entirely absent from the catalogue after the refactor.

- **Llama-Krikri** added to section 2, Llama-3.1 continual pretraining for Greek, Instruct updated 12/2025, Greek evaluation datasets still updated in 2026.
- **Meltemi-7B** added to section 3, first open LLM for Greek (Mistral-based, Apache 2.0, paper [arXiv:2407.20743](https://arxiv.org/abs/2407.20743)), now succeeded by Krikri. Split across two sections rather than one row, following the Lucie / Luciole precedent.

## From #7, Tilde

- **TildeOpen LLM** added to section 1 rather than to a bottom-of-page list: 30B trained from scratch, CC-BY-4.0, 34 European languages, 2M GPU hours on LUMI won through the EuroHPC Large AI Grand Challenge. That is a European frontier foundation model by the criteria of section 1.
- **Tilde AI** row in section 2 kept, with Latvia as the origin since the company is headquartered in Riga. The original PR deleted the row entirely, but Tilde also runs offices in Vilnius and Tallinn and the MT and services activity is still worth cataloguing.

Refs #6, #7