### PR TITLE
lower the barrier to contribution, restore dropped entries, add catalogue checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-project.yml
+++ b/.github/ISSUE_TEMPLATE/add-project.yml
@@ -1,0 +1,104 @@
+name: Add a project to the catalogue
+description: Suggest a European open-source LLM project, model, dataset or organisation. No git required.
+title: "Add: "
+labels: ["new entry"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping keep the catalogue alive.
+
+        Fill in what you know and leave the rest blank, a maintainer will turn
+        this into a catalogue row. If you would rather send the row yourself,
+        the README has a copy-paste template for each section.
+
+  - type: input
+    id: name
+    attributes:
+      label: Project name
+      description: The name as you would like it to appear, plus the organisation behind it.
+      placeholder: Llama-Krikri (ILSP, Athena Research Center)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: section
+    attributes:
+      label: Which section does it belong to?
+      description: If you are unsure, pick your best guess and say why in the notes.
+      options:
+        - 1. Foundation models, European frontier
+        - 2. National and community LLMs (active)
+        - 3. Archives and historical models
+        - 4. Reoriented or acquired projects
+        - Ecosystem organisations and infrastructures
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: origin
+    attributes:
+      label: Country or origin
+      placeholder: Greece
+    validations:
+      required: true
+
+  - type: input
+    id: languages
+    attributes:
+      label: Languages covered
+      placeholder: el, en
+
+  - type: input
+    id: license
+    attributes:
+      label: License
+      description: Apache 2.0, CC-BY-4.0, a custom model license, or "mixed" for a commercial project with some open artefacts.
+      placeholder: Apache 2.0
+
+  - type: input
+    id: latest
+    attributes:
+      label: Latest release or activity
+      description: A date we can point to, not "actively maintained".
+      placeholder: 8B Instruct, 12/2025
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links and evidence
+      description: |
+        At least one public artefact: a Hugging Face model or dataset card, a
+        repository, a paper, or an official announcement. This is what makes
+        the entry verifiable.
+      placeholder: |
+        https://huggingface.co/ilsp
+        https://arxiv.org/abs/2407.20743
+    validations:
+      required: true
+
+  - type: input
+    id: contact
+    attributes:
+      label: Public contact (optional)
+      description: A mailing list, contact form or LinkedIn page. Please do not post someone's personal email without their consent.
+      placeholder: https://www.linkedin.com/company/example
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: Why this belongs in the catalogue, or which existing entry it relates to.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you submit
+      options:
+        - label: The project has a public artefact (model card, dataset card, repository or paper), not just a website.
+          required: true
+        - label: It is European, or run by a European team. Adjacent non-European projects are out of scope.
+          required: true
+        - label: Any contact I listed is already public, and I am not adding someone's personal email without their consent.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask the community
+    url: https://discord.gg/8cHZ6NVwxd
+    about: Questions about the catalogue, or unsure whether a project fits, come and ask on Discord.

--- a/.github/ISSUE_TEMPLATE/update-entry.yml
+++ b/.github/ISSUE_TEMPLATE/update-entry.yml
@@ -1,0 +1,40 @@
+name: Update or fix an existing entry
+description: Report a stale release date, a dead link, or a project whose status has changed.
+title: "Update: "
+labels: ["update"]
+body:
+  - type: input
+    id: entry
+    attributes:
+      label: Which entry?
+      placeholder: Teuken-7B (OpenGPT-X / Fraunhofer IAIS / Jülich)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What needs changing?
+      options:
+        - The "Latest release" or "Latest activity" column is out of date
+        - A link is dead or points to the wrong place
+        - The project should move to another section (inactive, acquired, superseded)
+        - Something in the row is factually wrong
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: change
+    attributes:
+      label: What should it say instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: A Hugging Face page, repository, paper or official announcement that backs the change.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## What this changes
+
+<!-- One line. Which project, which section. -->
+
+## Evidence
+
+<!--
+Link the public artefact that backs this change: a Hugging Face model or
+dataset card, a repository, a paper, or an official announcement.
+-->
+
+## Checklist
+
+- [ ] I used the row template for the right section, so my row has the right number of columns
+- [ ] My row is inserted in alphabetical order inside its table
+- [ ] I changed my row and nothing else, no reformatting of the rest of the table
+- [ ] Every link resolves, and any contact listed is an existing public contact

--- a/.github/scripts/check_tables.py
+++ b/.github/scripts/check_tables.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
-"""Check that every markdown table row has as many cells as its header.
+"""Structural checks for the catalogue.
 
-The catalogue is one big file made of six tables with five different column
-shapes, so a row copied from the wrong section renders with shifted or missing
-cells. GitHub silently drops the extra cells, which is how a broken row can sit
-in the catalogue unnoticed.
+1. Every table row has as many cells as its table header. The catalogue is one
+   file made of six tables with five different column shapes, so a row copied
+   from the wrong section renders with shifted or missing cells. GitHub drops
+   the extra cells silently, which is how a broken row can sit unnoticed.
+
+2. Every row template in the "How to contribute" section still matches a real
+   table header. Templates are what contributors copy, so they must not drift
+   when a section gains or loses a column.
 
 Usage: python3 .github/scripts/check_tables.py README.md
 """
@@ -12,6 +16,7 @@ Usage: python3 .github/scripts/check_tables.py README.md
 import re
 import sys
 
+FENCE = re.compile(r"^\s*(?:```|~~~)(.*)$")
 DELIMITER = re.compile(r"^\|(?:\s*:?-{3,}:?\s*\|)+$")
 SPLIT_CELLS = re.compile(r"(?<!\\)\|")
 
@@ -26,16 +31,42 @@ def cell_count(line):
     return len(parts)
 
 
+def normalise(line):
+    return " ".join(line.split())
+
+
+def scan(lines):
+    """Yield (line_number, line, inside_template) for every table-ish line."""
+    fence = None
+    for number, line in enumerate(lines, start=1):
+        match = FENCE.match(line)
+        if match:
+            info = match.group(1).strip()
+            if fence is None:
+                fence = info
+            elif info == "":
+                fence = None
+            continue
+        if not line.lstrip().startswith("|"):
+            yield number, None, fence
+            continue
+        yield number, line, fence
+
+
 def check(path):
     with open(path, encoding="utf-8") as handle:
         lines = handle.read().split("\n")
 
     problems = []
+    real_headers = set()
+    template_headers = []
+
     expected = None
     header_line = None
+    header_text = None
 
-    for number, line in enumerate(lines, start=1):
-        if not line.lstrip().startswith("|"):
+    for number, line, fence in scan(lines):
+        if line is None:
             expected = None
             continue
 
@@ -50,13 +81,26 @@ def check(path):
         if expected is None:
             expected = cell_count(line)
             header_line = number
+            header_text = normalise(line)
+            if fence is None:
+                real_headers.add(header_text)
+            elif fence == "markdown":
+                template_headers.append((number, header_text))
             continue
 
         found = cell_count(line)
         if found != expected:
+            where = "template row" if fence is not None else "row"
             problems.append(
-                f"{path}:{number}: row has {found} columns, "
+                f"{path}:{number}: {where} has {found} columns, "
                 f"header on line {header_line} has {expected}"
+            )
+
+    for number, header in template_headers:
+        if header not in real_headers:
+            problems.append(
+                f"{path}:{number}: row template header does not match any table "
+                f"in the catalogue, it has drifted from the section it documents"
             )
 
     return problems
@@ -67,7 +111,7 @@ def main():
     problems = [problem for path in paths for problem in check(path)]
 
     if problems:
-        print("Table structure check failed:\n")
+        print("Catalogue structure check failed:\n")
         for problem in problems:
             print(f"  {problem}")
         print(
@@ -76,7 +120,7 @@ def main():
         )
         return 1
 
-    print(f"Table structure check passed for: {', '.join(paths)}")
+    print(f"Catalogue structure check passed for: {', '.join(paths)}")
     return 0
 
 

--- a/.github/scripts/check_tables.py
+++ b/.github/scripts/check_tables.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Check that every markdown table row has as many cells as its header.
+
+The catalogue is one big file made of six tables with five different column
+shapes, so a row copied from the wrong section renders with shifted or missing
+cells. GitHub silently drops the extra cells, which is how a broken row can sit
+in the catalogue unnoticed.
+
+Usage: python3 .github/scripts/check_tables.py README.md
+"""
+
+import re
+import sys
+
+DELIMITER = re.compile(r"^\|(?:\s*:?-{3,}:?\s*\|)+$")
+SPLIT_CELLS = re.compile(r"(?<!\\)\|")
+
+
+def cell_count(line):
+    parts = SPLIT_CELLS.split(line.strip())
+    # A well-formed row starts and ends with a pipe, so drop the empty edges.
+    if parts and parts[0].strip() == "":
+        parts = parts[1:]
+    if parts and parts[-1].strip() == "":
+        parts = parts[:-1]
+    return len(parts)
+
+
+def check(path):
+    with open(path, encoding="utf-8") as handle:
+        lines = handle.read().split("\n")
+
+    problems = []
+    expected = None
+    header_line = None
+
+    for number, line in enumerate(lines, start=1):
+        if not line.lstrip().startswith("|"):
+            expected = None
+            continue
+
+        if DELIMITER.match(line.strip()):
+            if expected is not None and cell_count(line) != expected:
+                problems.append(
+                    f"{path}:{number}: separator has {cell_count(line)} columns, "
+                    f"header on line {header_line} has {expected}"
+                )
+            continue
+
+        if expected is None:
+            expected = cell_count(line)
+            header_line = number
+            continue
+
+        found = cell_count(line)
+        if found != expected:
+            problems.append(
+                f"{path}:{number}: row has {found} columns, "
+                f"header on line {header_line} has {expected}"
+            )
+
+    return problems
+
+
+def main():
+    paths = sys.argv[1:] or ["README.md"]
+    problems = [problem for path in paths for problem in check(path)]
+
+    if problems:
+        print("Table structure check failed:\n")
+        for problem in problems:
+            print(f"  {problem}")
+        print(
+            "\nEach section has its own columns. Copy the row template for the "
+            "right section from the 'How to contribute' part of the README."
+        )
+        return 1
+
+    print(f"Table structure check passed for: {', '.join(paths)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/catalogue-checks.yml
+++ b/.github/workflows/catalogue-checks.yml
@@ -1,0 +1,23 @@
+name: Catalogue checks
+
+on:
+  pull_request:
+    paths:
+      - "README.md"
+      - ".github/scripts/check_tables.py"
+      - ".github/workflows/catalogue-checks.yml"
+  push:
+    branches: [main]
+    paths:
+      - "README.md"
+  workflow_dispatch:
+
+jobs:
+  tables:
+    name: Table structure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check that every row matches its table header
+        run: python3 .github/scripts/check_tables.py README.md

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,43 @@
+name: Link check
+
+# The catalogue is a list of links, so link rot is its main way of going stale.
+# This runs on a schedule rather than on pull requests: some project sites
+# answer 403 to automated clients, and a contributor adding one good row should
+# never be blocked by an unrelated dead link somewhere else in the file.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  links:
+    name: Find dead links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-retries 2
+            --timeout 20
+            --accept 200,206,403,429
+            README.md
+          output: ./lychee/out.md
+          fail: false
+
+      - name: Open or update the dead links issue
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Dead links in the catalogue
+          content-filepath: ./lychee/out.md
+          labels: maintenance

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ We're **OpenLLM France** :fr::eu:, an Open Source community committed to empower
 
 This repository maintains a **curated, living catalogue** of European open-source LLM projects, models, datasets, and initiatives. It is intentionally opinionated: projects are grouped by role in the ecosystem rather than by nationality alone, and inactive artefacts are archived rather than deleted, so the map stays honest.
 
+> **Your project is missing?** Adding it takes two minutes and no git: open the [Add a project form](https://github.com/OpenLLM-Europe/European-OpenLLM-Projects/issues/new?template=add-project.yml) and we turn it into a catalogue row. Prefer a pull request? Copy the [row template](#row-templates) for the right section. Spotted a stale date or a dead link? [Tell us](https://github.com/OpenLLM-Europe/European-OpenLLM-Projects/issues/new?template=update-entry.yml).
+
 ---
 
 ## How to read this catalogue
@@ -153,16 +155,103 @@ The following organisations are **not models** but structure the European open-s
 
 ## How to contribute
 
-We welcome PRs that:
+Two ways in, pick whichever suits you.
+
+**1. Open an issue, no git needed.** Fill the [Add a project form](https://github.com/OpenLLM-Europe/European-OpenLLM-Projects/issues/new?template=add-project.yml) and a maintainer turns it into a catalogue row. Use the [update form](https://github.com/OpenLLM-Europe/European-OpenLLM-Projects/issues/new?template=update-entry.yml) for a stale date, a dead link, or a project whose status has changed. This is the recommended path if pull requests are not your daily tool.
+
+**2. Send a pull request.** Copy the [row template](#row-templates) for the right section, fill it in, open the pull request.
+
+### What we accept
 
 - Add a **missing European open-source project** with a public artefact (model card, dataset card, or repository).
 - **Update the "Latest release" column** with an evidence link (Hugging Face, GitHub, arXiv, or an official press release).
 - **Move a project** across sections when its status changes, for example from section 2 to section 3 when a project becomes inactive, or from section 1 to section 4 after an acquisition.
 - Add or fix links.
 
-Please keep entries **short, evidence-based, and honest**. This catalogue is designed to help European teams find each other and build together, not to advertise vapourware. When in doubt, open an issue first.
+### House rules
 
-Every listed contact is an existing public contact for the project (mailing list, contact form, LinkedIn). Please do not add personal emails without the person's consent.
+- **One project per pull request.** The whole catalogue lives in a single file, so small pull requests are what keeps contributors from conflicting with each other.
+- **Rows are sorted alphabetically** inside each table. Insert yours in the right place rather than at the end.
+- **Touch your row and nothing else.** No reformatting, no reflowing the rest of the table.
+- **Match the column count of the section you are editing.** The six tables do not share the same columns, and a row copied from another section renders broken. A check runs on every pull request to catch this.
+- Keep entries **short, evidence-based, and honest**. This catalogue is designed to help European teams find each other and build together, not to advertise vapourware. When in doubt, open an issue first.
+- Every listed contact must be an **existing public contact** for the project (mailing list, contact form, LinkedIn). Please do not add personal emails without the person's consent.
+
+### Row templates
+
+Copy the block for your section, replace the placeholders, and paste your single row into the table. The header and separator lines are shown so you can see the shape, do not paste them.
+
+<details>
+<summary><b>1. Foundation models, European frontier</b> &mdash; 7 columns</summary>
+
+```markdown
+| Model / family | Sizes | Languages | License | Latest release | Origin | Links |
+| --- | --- | --- | --- | --- | --- | --- |
+| **Model name** (organisation) | 7B, 70B | fr, en + EU | Apache 2.0 | MM/YYYY | Country | [site](https://example.org), [HF](https://huggingface.co/example) |
+```
+
+</details>
+
+<details>
+<summary><b>Speech, multimodal and agent foundation models</b> &mdash; 6 columns</summary>
+
+```markdown
+| Model | Modalities | License | Latest release | Origin | Links |
+| --- | --- | --- | --- | --- | --- |
+| **Model name** (organisation) | speech-to-speech, 7B | Apache 2.0 | MM/YYYY | :eu: Country | [site](https://example.org), [HF](https://huggingface.co/example) |
+```
+
+</details>
+
+<details>
+<summary><b>2. National and community LLMs (active)</b> &mdash; 6 columns</summary>
+
+```markdown
+| Project | Country / origin | Focus | License | Latest activity | Links |
+| --- | --- | --- | --- | --- | --- |
+| **Project name** (organisation) | :eu: Country | What it works on | Apache 2.0 | What shipped and when | [site](https://example.org), [HF](https://huggingface.co/example) |
+```
+
+</details>
+
+<details>
+<summary><b>3. Archives and historical models</b> &mdash; 4 columns</summary>
+
+```markdown
+| Model | Language | Origin | Links |
+| --- | --- | --- | --- |
+| **Model name** (organisation) | xx | :eu: Country | [HF](https://huggingface.co/example) - one line of lineage, what superseded it |
+```
+
+</details>
+
+<details>
+<summary><b>4. Reoriented or acquired projects</b> &mdash; 4 columns</summary>
+
+```markdown
+| Project | Status | What happened | Links |
+| --- | --- | --- | --- |
+| **Project name** | Acquired / Superseded / Reoriented | One sentence, with the date | [announcement](https://example.org) |
+```
+
+</details>
+
+<details>
+<summary><b>Ecosystem organisations and infrastructures</b> &mdash; 3 columns</summary>
+
+```markdown
+| Organisation | Role | Links |
+| --- | --- | --- |
+| **Organisation name** | What it does for the ecosystem | [site](https://example.org) |
+```
+
+</details>
+
+Before opening the pull request you can run the same check as CI:
+
+```bash
+python3 .github/scripts/check_tables.py README.md
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Openly licensed foundation LLMs trained from scratch in Europe (or by European t
 | **Alfred Sovereign v5** (LightOn) | text (RAG-oriented) | open weights + Paradigm platform | Alfred-sv5 (24B), 2025-2026 | :fr: France | [LightOn docs](https://docs.lighton.ai/en/developer-resources/lighton-models/alfred-sv5) |
 | **Holo-1 / Surfer H** (H Company) | vision-language action model (web agents) | Apache 2.0 (open weights) | Holo-1 3B and 7B, 06/2025, Holo 3 in 2026 | :fr: France | [hcompany.ai](https://hcompany.ai/), [Surfer H CLI](https://github.com/hcompai/surfer-h-cli) |
 | **Moshi / Moshika** (Kyutai) | full-duplex speech-to-speech | code MIT + Apache 2.0, weights CC-BY 4.0 | Public release 09/2024, TTS 1.6B and Unmute in 2026 | :fr: France | [kyutai.org](https://kyutai.org/), [GitHub](https://github.com/kyutai-labs/moshi) |
-| **Voxtral** (Mistral AI) | speech understanding + TTS + transcription (3B, 4B, 24B) | multilingual (up to 13 languages) | Apache 2.0 (understanding, Realtime), CC-BY-NC 4.0 (TTS) | Voxtral 07/2025, Transcribe 2 02/2026, TTS 03/2026 | :fr: France | [mistral.ai](https://mistral.ai/news/voxtral/), [Transcribe 2](https://mistral.ai/news/voxtral-transcribe-2/), [TTS](https://mistral.ai/news/voxtral-tts/) |
+| **Voxtral** (Mistral AI) | speech understanding + TTS + transcription (3B, 4B, 24B), multilingual up to 13 languages | Apache 2.0 (understanding, Realtime), CC-BY-NC 4.0 (TTS) | Voxtral 07/2025, Transcribe 2 02/2026, TTS 03/2026 | :fr: France | [mistral.ai](https://mistral.ai/news/voxtral/), [Transcribe 2](https://mistral.ai/news/voxtral-transcribe-2/), [TTS](https://mistral.ai/news/voxtral-tts/) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,15 @@ Living projects with real 2024-2026 releases, typically focused on one or a few 
 | Project | Country / origin | Focus | License | Latest activity | Links |
 | --- | --- | --- | --- | --- | --- |
 | **AI Sweden** | :sweden: Sweden | GPT-SW3, Nordic models | mixed | Institutional programme, ongoing | [ai.se](https://www.ai.se/en) |
+| **Beia Consult International** | :ro: Romania | Romanian speech and NLP, ASR, TTS and chatbots, inside EU research projects | mixed | R&D SME, active across FP7, H2020 and Horizon Europe projects | [beia.ro](https://beia.ro/), [EU projects](https://beiaro.eu/) |
+| **Blip.solutions** | :slovakia: Slovakia | Open-source LLM tooling, langchain-decorators and prompt tracing | MIT | langchain-decorators still updated 04/2026 | [blip.solutions](https://www.blip.solutions/), [GitHub](https://github.com/ju-bezdek/langchain-decorators) |
 | **Claire family** (OpenLLM France) | :fr: France | French conversational | Apache 2.0 | 2023-2024 (predecessor to Lucie/Luciole) | [HF](https://huggingface.co/OpenLLM-France) |
 | **CroAI** | :croatia: Croatia | Croatian AI community | open | Active community | [croai.org](https://www.croai.org/) |
 | **Croissant LLM** (CentraleSupélec + Illuin) | :fr: France | fr-en bilingual, small model | open | Reference 1.3B bilingual model | [HF](https://huggingface.co/croissantllm) |
 | **Danish Foundation Models** (Munin family) | :denmark: Denmark | Danish | open | Munin 7B alpha 2024, continued in 2025 | [HF](https://huggingface.co/danish-foundation-models) |
 | **DanskGPT** | :denmark: Denmark | Danish assistant | mixed | Public 2024-2025 | [danskgpt.dk](https://www.danskgpt.dk/) |
 | **EMBEDDIA / SloBERTa** | :lithuania: Lithuania / :slovenia: Slovenia | Baltic and Slavic | open (research) | Historical family, still used | [embeddia.eu](http://embeddia.eu/) |
+| **Expert AI** | :it: Italy | Hybrid neuro-symbolic NLP, knowledge graphs combined with LLMs | mixed | Active commercial + research | [expert.ai](https://www.expert.ai/) |
 | **Fauno Italian LLM** (Sapienza) | :it: Italy | Italian | open | Reference release 2023-2024 | [GitHub](https://github.com/RSTLess-research/Fauno-Italian-LLM) |
 | **Going Dutch, GEITje** | :netherlands: Netherlands | Dutch | open | Community-maintained | [Blog](https://goingdutch.ai/en/posts/introducing-geitje/) |
 | **Hilanco** | :hungary: Hungary | Hungarian | open | Community project | [hilanco.github.io](https://hilanco.github.io/home.html) |
@@ -82,6 +85,7 @@ Living projects with real 2024-2026 releases, typically focused on one or a few 
 | **Llama-Krikri** (ILSP, Athena Research Center) | :greece: Greece | Greek LLMs and Greek evaluation suite | Llama 3.1 | Krikri 8B Instruct updated 12/2025, Greek evaluation datasets updated 2026 | [Krikri collection](https://huggingface.co/collections/ilsp/krikri-8b-68273283651ba864d44fc33a), [Greek evaluation suite](https://huggingface.co/collections/ilsp/ilsp-greek-evaluation-suite-6827304d5bf8b70d0346b02c), [ILSP on HF](https://huggingface.co/ilsp) |
 | **LLM for Romanian (ILDS)** | :ro: Romania | Romanian | open (research) | Active 2024-2025 | [ilds.ro](https://ilds.ro/llm-for-romanian/) |
 | **NLP Odyssey** | :it: Italy | NLP libs and models | open | Active OpenCollective | [OpenCollective](https://opencollective.com/nlpodyssey) |
+| **Nordavind, nordic-ner** (Tollef Jørgensen, NTNU and Sikt) | :norway: Norway | Norwegian and Nordic fine-tunes, NER and evaluation datasets | open | Nordavind Llama 3.1 8B 02/2025, Nordic NER and Norwegian STS datasets | [HF](https://huggingface.co/tollefj), [Norwegian LLMs collection](https://huggingface.co/collections/tollefj/norwegian-llms) |
 | **NOUS Research** | :gb: United Kingdom | Instruction & alignment | mixed open | Regular releases in 2025-2026 | [HF](https://huggingface.co/NousResearch) |
 | **PORO / Viking / Europa** (ex-Silo AI, now AMD) | :fi: Finland / International | Nordic + multilingual | Apache 2.0 | Models still openly available, roadmap now under AMD | [Announcement](https://www.silo.ai/blog/poro-a-family-of-open-models-that-bring-european-languages-to-the-frontier) |
 | **SiloGen platform** (AMD, ex-Silo AI) | :fi: Finland (AMD) | Enterprise LLM ops | mixed | Post-acquisition 2024+ | See section 4 |
@@ -110,7 +114,7 @@ First-generation BERT-family models and early monolingual encoders. Based on pub
 | **SloBERTa** | sl | :slovenia: Slovenia | [HF](https://huggingface.co/EMBEDDIA/sloberta) |
 | **YugoGPT** | Serbo-Croatian family | :serbia: Serbia, :croatia: Croatia, :bosnia_herzegovina: Bosnia and Herzegovina, :macedonia: North Macedonia, :kosovo: Kosovo | [yugochat.com](https://www.yugochat.com/) |
 
-> Adjacent, non-European projects (LangFuse, Sayhan and Sestek, AI Forever, Yandex YaLM, EleutherAI) previously listed at repo level are no longer catalogued here. They are excellent references but out of scope for a European catalogue.
+> Adjacent, non-European projects (LangFuse, Sayhan and Sestek, AI Forever, Yandex YaLM, Evidently AI, EleutherAI) previously listed at repo level are no longer catalogued here. They are excellent references but out of scope for a European catalogue. Two further entries were dropped rather than archived: **Statisfied**, whose site no longer resolves, and **Sosnitskij**, a Hugging Face account republishing quantised Russian models with no activity since 02/2024.
 
 ---
 
@@ -144,6 +148,7 @@ The following organisations are **not models** but structure the European open-s
 | **EuroHPC JU** | European supercomputing joint undertaking (LUMI, Leonardo, JUWELS, MareNostrum 5, Jupiter, Alice Recoque) | [eurohpc-ju.europa.eu](https://eurohpc-ju.europa.eu/) |
 | **Fraunhofer IAIS** | Coordinator of OpenGPT-X, TrustLLM, Eurolingua | [iais.fraunhofer.de](https://www.iais.fraunhofer.de/en.html) |
 | **GENCI + Jules Verne consortium** | French national HPC, hosting Jean Zay, leading the **Alice Recoque** Exascale system for EuroHPC | [genci.fr](https://www.genci.fr) |
+| **GFOSS, Open Technologies Alliance** | Greek non-profit backed by 38 universities and research centres, runs GlossAPI to strengthen Greek in NLP | [gfoss.eu](https://gfoss.eu/), [GitHub](https://github.com/eellak) |
 | **LLMs4EU** | Flagship ALT-EDIC project | [ALT-EDIC, LLMs4EU](https://www.alt-edic.eu/projects/llms4eu/) |
 | **Luxembourg Institute of Science and Technology (LIST), Trustworthy AI group** | Research on trustworthy AI at EU level | [list.lu](https://www.list.lu/en/environment/research-groups/group/trustworthy-ai/) |
 | **Open Source Initiative (OSI)** | Maintains the **Open Source AI Definition (OSAID)** | [opensource.org](https://opensource.org/) |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # European Open Source LLM Projects :eu:
 
-We're **OpenLLM France** :fr::eu:, an Open Source community committed to empowering LLM projects in all European languages, with a specific focus on medium and low-resource languages.
+We're **OpenLLM Europe** :eu:, an Open Source community committed to empowering LLM projects in all European languages, with a specific focus on medium and low-resource languages.
 
 - Website: <https://openllm-france.fr/>
 - Discord: <https://discord.gg/8cHZ6NVwxd>


### PR DESCRIPTION
Stacked on #9, which ports the two stale contributions. GitHub retargets this to `main` automatically once #9 is merged. Review #9 first.

## Lower the barrier to contribution

Contributing used to mean adding a bullet under your country. Since the August 2026 restructure it means filling a seven column row, and there was nothing in the file explaining the shape. Both pull requests opened after the restructure were written in the old format, which is the symptom.

- **Call to action at the top of the README.** `How to contribute` was at line 151 of 166.
- **Issue-first path.** Two GitHub issue forms, `Add a project` and `Update or fix an existing entry`, so researchers who do not live in git can contribute without opening a pull request. Both ask for the evidence link the catalogue rules already require.
- **A copy-paste row template for each of the six tables**, in collapsed `<details>` blocks so they do not bloat the page.
- **The house rules, written down**: alphabetical order inside each table, one project per pull request, do not reformat the rest of the table. All three were previously only knowable by reading a diff.
- A pull request template with the same checklist.

## Restore entries dropped by the refactor

The restructure removed eight entries with no trace and no note. Four are collateral and come back:

| Entry | Where | Why |
| --- | --- | --- |
| **GFOSS, Open Technologies Alliance** | Ecosystem organisations | Greek non-profit backed by 38 universities, runs GlossAPI to strengthen Greek in NLP |
| **Expert AI** | Section 2 | Italian hybrid neuro-symbolic NLP |
| **Beia Consult International** | Section 2 | Romanian speech and NLP across FP7, H2020 and Horizon Europe projects |
| **Nordavind, nordic-ner** (Tollef Jørgensen, NTNU and Sikt) | Section 2 | Norway was otherwise entirely absent from the catalogue |

Three are deliberately left out, and now documented in the archives note instead of vanishing silently: **Evidently AI** is headquartered in San Francisco and falls under the same out-of-scope rule that removed LangFuse, **statisfied.io** no longer resolves, and **Sosnitskij** republishes quantised Russian models and has been idle since 02/2024.

## Fix the Voxtral row

It carried a `multilingual (up to 13 languages)` cell inherited from the section 1 header, so 7 cells against a 6 column header. GitHub shifted the cells and dropped the last one, which is why the Mistral links did not render.

## Catalogue checks

- **Table structure**, on every pull request. Catches rows copied from the wrong section, the exact failure that broke the Voxtral row. It also verifies that each row template still matches the header of the section it documents, so the templates cannot drift after the next restructure. Runnable locally with `python3 .github/scripts/check_tables.py README.md`.
- **Link check**, weekly rather than on pull requests, opening an issue with what it finds. Some project sites answer 403 to automated clients, and a contributor adding one good row should never be blocked by unrelated link rot.

## Naming

The intro said `OpenLLM France` while the organisation, the repository and the About text say `OpenLLM Europe`, which is what #8 is about. The intro now matches. The website, Discord and contact links are unchanged and still point to OpenLLM France infrastructure.

Refs #8