### PR TITLE
point the community links at OpenLLM Europe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # European Open Source LLM Projects :eu:
 
-We're **OpenLLM Europe** :eu:, an Open Source community committed to empowering LLM projects in all European languages, with a specific focus on medium and low-resource languages.
+We're **OpenLLM Europe** :eu:, an Open Source community committed to empowering LLM projects in all European languages, with a specific focus on medium and low-resource languages. Our working language is English.
 
-- Website: <https://openllm-france.fr/>
-- Discord: <https://discord.gg/8cHZ6NVwxd>
-- GitHub: <https://github.com/OpenLLM-France>
-- Contact: <contact@openllm-france.org>
+- Discord: <https://discord.gg/8cHZ6NVwxd>, shared with OpenLLM France, see the note below
+- GitHub: <https://github.com/OpenLLM-Europe>
+- Contact: <contact@openllm-europe.org>
+- OpenLLM France, the community we grew out of: <https://openllm-france.fr/>
+
+> **About that Discord invite.** OpenLLM Europe started inside OpenLLM France and still shares its Discord server, so the invite opens a server named *OpenLLM France* and many of its channels are in French. That is lineage, not policy. European discussions and this catalogue run in English, so open your thread in English wherever you land, and say so if a French-only conversation is in your way.
 
 This repository maintains a **curated, living catalogue** of European open-source LLM projects, models, datasets, and initiatives. It is intentionally opinionated: projects are grouped by role in the ecosystem rather than by nationality alone, and inactive artefacts are archived rather than deleted, so the map stays honest.
 


### PR DESCRIPTION
## What this changes

Fixes the intro block of the README. Reported in #8.

The page said "We're **OpenLLM Europe**" and then listed four `openllm-france` links, so a reader coming to a European catalogue landed on a Discord server named *OpenLLM France* with no explanation.

- Discord: unchanged invite, now labelled as shared with OpenLLM France, with a short note explaining why
- GitHub: `OpenLLM-France` → `OpenLLM-Europe`, the org that actually hosts this repo and the Manifesto
- Contact: `contact@openllm-france.org` → `contact@openllm-europe.org`, the address the Manifesto already publishes
- The French project's site stays listed, labelled as the community we grew out of
- Says explicitly that the working language is English

## Evidence

Both invites in circulation resolve to the same guild:

```
$ curl -s "https://discord.com/api/v9/invites/8cHZ6NVwxd?with_counts=true"   # this README
$ curl -s "https://discord.com/api/v9/invites/k2BQvGfjzA?with_counts=true"   # Manifesto, labelled "OpenLLM-Europe Discord server"
  guild.id   = 1118901058282999911
  guild.name = "OpenLLM France"
```

- `github.com/OpenLLM-Europe` hosts this repo and [Manifesto](https://github.com/OpenLLM-Europe/Manifesto), which is where `contact@openllm-europe.org` is published. That domain has live MX records, so the mailbox is real even though it serves no website.
- All four links return 200.

## Not addressed here

The note is honest about the server being historically French rather than pretending otherwise, because no English-language channel is named. Two follow-ups are worth considering separately:

1. The current invite lands on `#sync-soutenance-aap`. An invite targeting a general channel would be a friendlier entry point.
2. `Manifesto` still calls `discord.gg/k2BQvGfjzA` "the OpenLLM-Europe Discord server". Same server, same mismatch, different repo.

## Checklist

The template checklist covers catalogue rows and does not apply here, no table was touched. The relevant checks:

- [x] Every link resolves, and the contact listed is an existing public contact
- [x] `python3 .github/scripts/check_tables.py README.md` passes
- [x] Intro block only, no other part of the README reflowed